### PR TITLE
Added waitlist activity, US 01.01.01 – see events you joined, US 01.0…

### DIFF
--- a/code/app/src/main/AndroidManifest.xml
+++ b/code/app/src/main/AndroidManifest.xml
@@ -54,6 +54,15 @@
         <activity
             android:name=".EntrantNotificationOptions"
             android:exported="false" />
+        <!-- Entrant Event Detail Screen -->
+        <activity android:name=".activities.EventDetailActivity"
+            android:exported="false" />
+        <activity android:name=".activities.ConfirmationActivity"
+            android:exported="false" />
+
+        <activity android:name=".activities.WaitListActivity"
+            android:exported="false" />
+
 
         <!-- Organizer-only entry: no Entrant/Admin UI -->
         <activity

--- a/code/app/src/main/java/com/example/waitwell/activities/AllEventsActivity.java
+++ b/code/app/src/main/java/com/example/waitwell/activities/AllEventsActivity.java
@@ -1,5 +1,6 @@
 package com.example.waitwell.activities;
 
+import android.content.Intent;
 import android.os.Bundle;
 import android.text.Editable;
 import android.text.TextWatcher;
@@ -24,6 +25,7 @@ import java.util.ArrayList;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
+
 
 /**
  * All Events screen with search and filter.
@@ -308,8 +310,9 @@ public class AllEventsActivity extends AppCompatActivity {
             View root = row.findViewById(R.id.rowRoot);
             root.setBackgroundResource(isOpen ? R.drawable.bg_event_row : R.drawable.bg_event_row_closed);
             row.setOnClickListener(v -> {
-                Toast.makeText(this, "Event detail (id: " + eventId + ")", Toast.LENGTH_SHORT).show();
-                //TODO
+                Intent i = new Intent(this, EventDetailActivity.class);
+                i.putExtra("event_id", eventId);
+                startActivity(i);
             });
             eventsListContainer.addView(row);
         }
@@ -322,8 +325,7 @@ public class AllEventsActivity extends AppCompatActivity {
             int id = item.getItemId();
             if (id == R.id.nav_home) { finish(); return true; }
             if (id == R.id.nav_waitlist) {
-                Toast.makeText(this, "Wait List ", Toast.LENGTH_SHORT).show();
-                //todo
+                startActivity(new Intent(this, WaitListActivity.class));
                 return true;
             }
             if (id == R.id.nav_notifications) {

--- a/code/app/src/main/java/com/example/waitwell/activities/ConfirmationActivity.java
+++ b/code/app/src/main/java/com/example/waitwell/activities/ConfirmationActivity.java
@@ -1,0 +1,38 @@
+package com.example.waitwell.activities;
+
+import android.content.Intent;
+import android.os.Bundle;
+import android.widget.TextView;
+
+import androidx.appcompat.app.AppCompatActivity;
+
+import com.example.waitwell.R;
+
+/**
+ * Shown after successfully joining a waitlist.
+ * Displays the event name and "You're on the waiting list!"
+ * with a button to go to the WaitListActivity.
+ */
+public class ConfirmationActivity extends AppCompatActivity {
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_confirmation);
+
+        String eventTitle = getIntent().getStringExtra("event_title");
+        if (eventTitle == null) eventTitle = "Event";
+
+        ((TextView) findViewById(R.id.txtEventName)).setText(eventTitle);
+        findViewById(R.id.btnMyWaitlist).setOnClickListener(v -> {
+            startActivity(new Intent(this, WaitListActivity.class));
+            finish();
+        });
+
+        // Back arrow - go back to main
+        findViewById(R.id.btnBack).setOnClickListener(v -> {
+            startActivity(new Intent(this, MainActivity.class));
+            finish();
+        });
+    }
+}

--- a/code/app/src/main/java/com/example/waitwell/activities/EventDetailActivity.java
+++ b/code/app/src/main/java/com/example/waitwell/activities/EventDetailActivity.java
@@ -1,0 +1,155 @@
+package com.example.waitwell.activities;
+
+import android.content.Intent;
+import android.os.Bundle;
+import android.util.Log;
+import android.view.View;
+import android.widget.TextView;
+import android.widget.Toast;
+
+import androidx.appcompat.app.AppCompatActivity;
+
+import com.example.waitwell.DeviceUtils;
+import com.example.waitwell.FirebaseHelper;
+import com.example.waitwell.R;
+import com.google.android.material.bottomnavigation.BottomNavigationView;
+import com.google.firebase.firestore.DocumentSnapshot;
+
+import java.util.List;
+
+/**
+ * Event detail screen (US 01.01.01 – join waitlist).
+ *
+ * Receives "event_id" via Intent extra, loads the event from Firestore,
+ * and shows all details. The "Join Waitlist Now" button calls
+ * FirebaseHelper.joinWaitlist() then navigates to the confirmation screen.
+ *
+ * If the user is already on this event's waitlist, the button is hidden and a message is shown instead.
+ */
+public class EventDetailActivity extends AppCompatActivity {
+
+    private static final String TAG = "EventDetailActivity";
+
+    private TextView txtTitle, txtLocation, txtPrice, txtRegistered;
+    private TextView txtTimeRemaining, txtRating, txtDescription;
+    private View btnJoin;
+    private String eventId, deviceId;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_event_detail);
+
+        deviceId = DeviceUtils.getDeviceId(this);
+        eventId = getIntent().getStringExtra("event_id");
+        if (eventId == null) { finish(); return; }
+
+        initViews();
+        loadEvent();
+        setupBottomNav();
+    }
+
+    private void initViews() {
+        txtTitle= findViewById(R.id.txtTitle);
+        txtLocation = findViewById(R.id.txtLocation);
+        txtPrice = findViewById(R.id.txtPrice);
+        txtRegistered = findViewById(R.id.txtRegistered);
+        txtTimeRemaining = findViewById(R.id.txtTimeRemaining);
+        txtRating = findViewById(R.id.txtRating);
+        txtDescription = findViewById(R.id.txtDescription);
+        btnJoin = findViewById(R.id.btnJoinWaitlist);
+
+        findViewById(R.id.btnBack).setOnClickListener(v -> finish());
+        btnJoin.setOnClickListener(v -> joinWaitlist());
+    }
+
+    private void loadEvent() {
+        FirebaseHelper.getInstance().getEvent(eventId)
+                .addOnSuccessListener(this::populateUI)
+                .addOnFailureListener(e -> {
+                    Log.e(TAG, "Failed to load event", e);
+                    Toast.makeText(this, "Could not load event", Toast.LENGTH_SHORT).show();
+                    finish();
+                });
+    }
+
+    @SuppressWarnings("unchecked")
+    private void populateUI(DocumentSnapshot doc) {
+        if (!doc.exists()) {
+            Toast.makeText(this, "Event not found", Toast.LENGTH_SHORT).show();
+            finish();
+            return;
+        }
+
+        String title = doc.getString("title");
+        String location = doc.getString("location");
+        String desc = doc.getString("description");
+        String status = doc.getString("status");
+        Double price = doc.getDouble("price");
+        Double rating = doc.getDouble("rating");
+        List<String> waitlist = (List<String>) doc.get("waitlistEntrantIds");
+
+        txtTitle.setText(title != null ? title : "");
+        txtLocation.setText(location != null ? location : "");
+        txtDescription.setText(desc != null ? desc : "");
+        txtPrice.setText(price != null ? String.format("$%.0f", price) : "Free");
+        txtRating.setText(rating != null ? String.format("%.1f", rating) : "—");
+
+        int count = (waitlist != null) ? waitlist.size() : 0;
+        txtRegistered.setText(count + " Registered");
+
+        boolean isOpen = "open".equals(status);
+        if (isOpen) {
+            txtTimeRemaining.setText("Open to register");
+        } else {
+            txtTimeRemaining.setText("Registration closed");
+        }
+
+        //Check if user is already on the waitlist
+        boolean alreadyJoined = waitlist != null && waitlist.contains(deviceId);
+
+        if (alreadyJoined || !isOpen) {
+            // Hide join button, show status text instead
+            findViewById(R.id.joinButtonContainer).setVisibility(View.GONE);
+            //Maybe add message that "You already joined the waitlist"
+            //TODO
+        }
+    }
+
+    // Join Waitlist (US 01.01.01)
+    private void joinWaitlist() {
+        btnJoin.setEnabled(false);
+        String title = txtTitle.getText().toString();
+        FirebaseHelper.getInstance().joinWaitlist(
+                deviceId, eventId, title,
+                task -> {
+                    if (task.isSuccessful()) {
+                        // Go to confirmation screen
+                        Intent intent = new Intent(this, ConfirmationActivity.class);
+                        intent.putExtra("event_title", title);
+                        startActivity(intent);
+                        finish();
+                    } else {
+                        Toast.makeText(this, "Failed to join waitlist", Toast.LENGTH_SHORT).show();btnJoin.setEnabled(true);}
+                });
+    }
+
+    private void setupBottomNav() {
+        BottomNavigationView nav = findViewById(R.id.bottomNavigation);
+        nav.setOnItemSelectedListener(item -> {
+            int id = item.getItemId();
+            if (id == R.id.nav_home) { finish(); return true; }
+            if (id == R.id.nav_waitlist) {
+                startActivity(new Intent(this, WaitListActivity.class));
+                return true;
+            }
+            if (id == R.id.nav_notifications) {
+                Toast.makeText(this, "Notifications ", Toast.LENGTH_SHORT).show();
+                //todo
+                return true;
+            }
+            return false;
+        });
+    }
+
+}

--- a/code/app/src/main/java/com/example/waitwell/activities/MainActivity.java
+++ b/code/app/src/main/java/com/example/waitwell/activities/MainActivity.java
@@ -116,11 +116,9 @@ public class MainActivity extends AppCompatActivity {
 
     /** Called when user taps an event card or row. */
     private void onEventCardClicked(String eventId) {
-        Toast.makeText(this, "Event detail (id: " + eventId + ")", Toast.LENGTH_SHORT).show();
-        // Later this will do:
-        // Intent i = new Intent(this, EventDetailActivity.class);
-        // i.putExtra("event_id", eventId);
-        // startActivity(i);
+        Intent i = new Intent(this, EventDetailActivity.class);
+        i.putExtra("event_id", eventId);
+        startActivity(i);
     }
 
 
@@ -173,10 +171,9 @@ public class MainActivity extends AppCompatActivity {
         nav.setOnItemSelectedListener(item -> {
             int id = item.getItemId();
             if (id == R.id.nav_home) {
-                // already here
                 return true;
             } else if (id == R.id.nav_waitlist) {
-                Toast.makeText(this, "Wait List ", Toast.LENGTH_SHORT).show();
+                startActivity(new Intent(this, WaitListActivity.class));
                 return true;
             } else if (id == R.id.nav_notifications) {
                 Toast.makeText(this, "Notifications", Toast.LENGTH_SHORT).show();

--- a/code/app/src/main/java/com/example/waitwell/activities/WaitListActivity.java
+++ b/code/app/src/main/java/com/example/waitwell/activities/WaitListActivity.java
@@ -1,0 +1,238 @@
+package com.example.waitwell.activities;
+
+import android.content.Intent;
+import android.os.Bundle;
+import android.util.Log;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.widget.LinearLayout;
+import android.widget.ScrollView;
+import android.widget.TextView;
+import android.widget.Toast;
+
+import androidx.appcompat.app.AlertDialog;
+import androidx.appcompat.app.AppCompatActivity;
+
+import com.example.waitwell.DeviceUtils;
+import com.example.waitwell.FirebaseHelper;
+import com.example.waitwell.R;
+import com.google.android.material.bottomnavigation.BottomNavigationView;
+import com.google.firebase.firestore.DocumentSnapshot;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * "Your WaitList" screen – shows every event the user has joined.
+ *
+ * US 01.01.01 – see events you joined
+ * US 01.01.02 – leave a waitlist via "Quit Waiting List"
+ *
+ * Each entry shows its status: Waiting / Selected / Rejected / Confirmed.
+ * Tapping a row navigates to that event's detail screen.
+ * The "Quit Waiting List" button lets the user pick which event to leave.
+ */
+public class WaitListActivity extends AppCompatActivity {
+
+    private static final String TAG = "WaitListActivity";
+
+    private LinearLayout entriesContainer;
+    private LinearLayout emptyState;
+    private ScrollView scrollEntries;
+    private View btnQuit;
+    private String deviceId;
+
+    private List<DocumentSnapshot> entryDocs = new ArrayList<>();
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_waitlist);
+
+        deviceId = DeviceUtils.getDeviceId(this);
+
+        entriesContainer = findViewById(R.id.entriesContainer);
+        emptyState = findViewById(R.id.emptyState);
+        scrollEntries = findViewById(R.id.scrollEntries);
+        btnQuit = findViewById(R.id.btnQuit);
+
+        btnQuit.setOnClickListener(v -> showQuitDialog());
+        setupBottomNav();
+    }
+
+    @Override
+    protected void onResume() {
+        super.onResume();
+        loadEntries();
+    }
+
+    private void loadEntries() {
+        FirebaseHelper.getInstance().getUserWaitlistEntries(deviceId)
+                .addOnSuccessListener(snap -> {
+                    entryDocs = snap.getDocuments();
+                    renderEntries();
+                })
+                .addOnFailureListener(e -> {
+                    Log.e(TAG, "Failed to load waitlist", e);
+                    Toast.makeText(this, "Could not load waitlist",
+                            Toast.LENGTH_SHORT).show();
+                });
+    }
+
+    private void renderEntries() {
+        entriesContainer.removeAllViews();
+        if (entryDocs.isEmpty()) {
+            scrollEntries.setVisibility(View.GONE);
+            emptyState.setVisibility(View.VISIBLE);
+            btnQuit.setVisibility(View.GONE);
+            return;
+        }
+
+        scrollEntries.setVisibility(View.VISIBLE);
+        emptyState.setVisibility(View.GONE);
+        btnQuit.setVisibility(View.VISIBLE);
+
+        LayoutInflater inflater = LayoutInflater.from(this);
+
+        for (int i = 0; i < entryDocs.size(); i++) {
+            DocumentSnapshot doc = entryDocs.get(i);
+
+            View row = inflater.inflate(R.layout.item_waitlist_entry, entriesContainer, false);
+
+            String title = doc.getString("eventTitle");
+            String status = doc.getString("status");
+            String eventId = doc.getString("eventId");
+
+            if (title == null) title = "Unknown Event";
+            if (status == null) status = "waiting";
+
+            ((TextView) row.findViewById(R.id.txtNumber)).setText((i + 1) + ".");
+            ((TextView) row.findViewById(R.id.txtEntryTitle)).setText(title);
+
+            // Status badge with colour
+            TextView badge = row.findViewById(R.id.txtEntryStatus);
+            applyStatusStyle(badge, status);
+
+            // Tap row - event detail
+            final String eid = eventId;
+            row.setOnClickListener(v -> {
+                if (eid != null) {
+                    Intent intent = new Intent(this, EventDetailActivity.class);
+                    intent.putExtra("event_id", eid);
+                    startActivity(intent);
+                }
+            });
+            entriesContainer.addView(row);
+        }
+    }
+
+    /**
+     * Applies the correct text, colour, and background to a status badge
+     * based on the entry's status string from Firestore.
+     */
+    private void applyStatusStyle(TextView badge, String status) {
+        switch (status) {
+            case "selected":
+                badge.setText("Selected");
+                badge.setBackgroundResource(R.drawable.bg_status_open);
+                badge.setTextColor(getColor(R.color.status_open_text));
+                break;
+            case "confirmed":
+                badge.setText("Confirmed");
+                badge.setBackgroundResource(R.drawable.bg_status_open);
+                badge.setTextColor(getColor(R.color.status_open_text));
+                break;
+            case "rejected":
+                badge.setText("Rejected");
+                badge.setBackgroundResource(R.drawable.bg_status_closed);
+                badge.setTextColor(getColor(R.color.status_closed_text));
+                break;
+            case "cancelled":
+                badge.setText("Cancelled");
+                badge.setBackgroundResource(R.drawable.bg_status_closed);
+                badge.setTextColor(getColor(R.color.status_closed_text));
+                break;
+            default: // "waiting"
+                badge.setText("Waiting");
+                badge.setBackgroundResource(R.drawable.bg_status_waiting);
+                badge.setTextColor(getColor(R.color.status_waiting_text));
+                break;
+        }
+    }
+
+    //Quit waitlist (US 01.01.02)
+    /**
+     * Shows a dialog listing only "waiting" entries — those are the
+     * ones the user can quit. Selected/confirmed have a different flow.
+     */
+    private void showQuitDialog() {
+        List<DocumentSnapshot> quittable = new ArrayList<>();
+        List<String> names = new ArrayList<>();
+
+        for (DocumentSnapshot doc : entryDocs) {
+            if ("waiting".equals(doc.getString("status"))) {
+                quittable.add(doc);
+                String t = doc.getString("eventTitle");
+                names.add(t != null ? t : "Unknown");
+            }
+        }
+
+        if (quittable.isEmpty()) {
+            Toast.makeText(this, "No active waitlists to leave", Toast.LENGTH_SHORT).show();
+            return;
+        }
+        new AlertDialog.Builder(this)
+                .setTitle("Quit Waiting List")
+                .setItems(names.toArray(new String[0]), (dialog, which) -> {
+                    DocumentSnapshot chosen = quittable.get(which);
+                    confirmQuit(chosen);
+                })
+                .setNegativeButton("Cancel", null)
+                .show();
+    }
+
+    private void confirmQuit(DocumentSnapshot entry) {
+        String title = entry.getString("eventTitle");
+        String eid   = entry.getString("eventId");
+
+        new AlertDialog.Builder(this)
+                .setTitle("Leave " + title + "?")
+                .setMessage("Are you sure you want to leave this waitlist?")
+                .setPositiveButton("Leave", (d, w) -> {
+                    FirebaseHelper.getInstance().leaveWaitlist(deviceId, eid,
+                            task -> {
+                                if (task.isSuccessful()) {
+                                    Toast.makeText(this, "Left " + title,
+                                            Toast.LENGTH_SHORT).show();
+                                    loadEntries(); // refresh
+                                } else {
+                                    Toast.makeText(this, "Failed to leave",
+                                            Toast.LENGTH_SHORT).show();
+                                }
+                            });
+                })
+                .setNegativeButton("Cancel", null)
+                .show();
+    }
+
+
+    private void setupBottomNav() {
+        BottomNavigationView nav = findViewById(R.id.bottomNavigation);
+        // Highlight the waitlist tab (middle)
+        nav.setSelectedItemId(R.id.nav_waitlist);
+        nav.setOnItemSelectedListener(item -> {
+            int id = item.getItemId();
+            if (id == R.id.nav_home) {
+                startActivity(new Intent(this, MainActivity.class));
+                finish();
+                return true;}
+            if (id == R.id.nav_waitlist) return true;
+            if (id == R.id.nav_notifications) {
+                Toast.makeText(this, "Notifications",
+                        Toast.LENGTH_SHORT).show();
+                return true;
+            }
+            return false;
+        });
+    }
+}

--- a/code/app/src/main/res/drawable/bg_button_join.xml
+++ b/code/app/src/main/res/drawable/bg_button_join.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="#343734" />
+    <corners android:radius="28dp" />
+</shape>

--- a/code/app/src/main/res/drawable/bg_button_my_waitlist.xml
+++ b/code/app/src/main/res/drawable/bg_button_my_waitlist.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="#333333" />
+    <corners android:radius="24dp" />
+</shape>

--- a/code/app/src/main/res/drawable/bg_button_quit.xml
+++ b/code/app/src/main/res/drawable/bg_button_quit.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="#E8A0A0" />
+    <corners android:radius="16dp" />
+</shape>

--- a/code/app/src/main/res/drawable/bg_circle_overlay.xml
+++ b/code/app/src/main/res/drawable/bg_circle_overlay.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="oval">
+    <solid android:color="#88555555" />
+</shape>

--- a/code/app/src/main/res/drawable/bg_confirmation_card.xml
+++ b/code/app/src/main/res/drawable/bg_confirmation_card.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="#D5F5D0" />
+    <corners android:radius="20dp" />
+</shape>

--- a/code/app/src/main/res/drawable/bg_status_waiting.xml
+++ b/code/app/src/main/res/drawable/bg_status_waiting.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="#FFF9C4" />
+    <corners android:radius="20dp" />
+</shape>

--- a/code/app/src/main/res/drawable/bg_title_overlay.xml
+++ b/code/app/src/main/res/drawable/bg_title_overlay.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+
+    <solid android:color="#801D1D1D" />
+
+    <corners android:radius="16dp" />
+
+</shape>

--- a/code/app/src/main/res/drawable/bg_waitlist_card.xml
+++ b/code/app/src/main/res/drawable/bg_waitlist_card.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="#FFFFFF" />
+    <corners android:radius="12dp" />
+    <stroke android:width="1dp" android:color="#EEEEEE" />
+</shape>

--- a/code/app/src/main/res/drawable/ic_circle.xml
+++ b/code/app/src/main/res/drawable/ic_circle.xml
@@ -1,0 +1,13 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:pathData="M3,12a9,9 0,1 0,18 0a9,9 0,1 0,-18 0"
+      android:strokeLineJoin="round"
+      android:strokeWidth="2"
+      android:fillColor="#00000000"
+      android:strokeColor="#848282"
+      android:strokeLineCap="round"/>
+</vector>

--- a/code/app/src/main/res/layout/activity_confirmation.xml
+++ b/code/app/src/main/res/layout/activity_confirmation.xml
@@ -1,0 +1,124 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:background="@color/bg_light">
+
+    <!-- Top bar -->
+    <RelativeLayout
+        android:layout_width="match_parent"
+        android:layout_height="56dp"
+        android:paddingStart="16dp"
+        android:paddingEnd="16dp">
+
+        <ImageButton
+            android:id="@+id/btnHamburger"
+            android:layout_width="40dp"
+            android:layout_height="40dp"
+            android:layout_alignParentStart="true"
+            android:layout_centerVertical="true"
+            android:background="?attr/selectableItemBackgroundBorderless"
+            android:src="@drawable/ic_menu_hamburger"
+            android:contentDescription="Menu" />
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_centerInParent="true"
+            android:text="@string/app_name"
+            android:textColor="@color/text_primary"
+            android:textSize="20sp"
+            android:textStyle="bold" />
+
+        <ImageView
+            android:layout_width="36dp"
+            android:layout_height="36dp"
+            android:layout_alignParentEnd="true"
+            android:layout_centerVertical="true"
+            android:src="@drawable/waitwell_logo"
+            android:contentDescription="Logo" />
+    </RelativeLayout>
+
+    <!-- Back arrow -->
+    <ImageView
+        android:id="@+id/btnBack"
+        android:layout_width="40dp"
+        android:layout_height="40dp"
+        android:layout_marginStart="12dp"
+        android:background="@drawable/bg_circle_overlay"
+        android:padding="10dp"
+        android:src="@drawable/ic_back_arrow"
+        android:contentDescription="Back"
+        android:clickable="true"
+        android:focusable="true" />
+
+    <!-- Centered confirmation content -->
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1"
+        android:gravity="center"
+        android:orientation="vertical"
+        android:padding="32dp">
+
+        <!-- Green confirmation card -->
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:background="@drawable/bg_confirmation_card"
+            android:gravity="center"
+            android:orientation="vertical"
+            android:padding="28dp">
+
+            <TextView
+                android:id="@+id/txtEventName"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="Yoga Hatha"
+                android:textColor="@color/text_primary"
+                android:fontFamily="@font/poppinsmedium"
+                android:textSize="24sp"
+                android:textStyle="bold"
+                android:gravity="center" />
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="8dp"
+                android:text="You're on the waiting list!"
+                android:fontFamily="@font/poppinsmedium"
+                android:textColor="@color/text_primary"
+                android:textSize="20sp"
+                android:textStyle="bold"
+                android:gravity="center" />
+        </LinearLayout>
+
+        <!-- My Waitlist button -->
+        <androidx.appcompat.widget.AppCompatButton
+            android:id="@+id/btnMyWaitlist"
+            android:layout_width="wrap_content"
+            android:layout_height="48dp"
+            android:layout_marginTop="24dp"
+            android:background="@drawable/bg_button_my_waitlist"
+            android:paddingStart="28dp"
+            android:paddingEnd="28dp"
+            android:text="My Waitlist"
+            android:fontFamily="@font/poppinsmedium"
+            android:textAllCaps="false"
+            android:textColor="#FFFFFF"
+            android:textSize="15sp" />
+
+    </LinearLayout>
+
+    <!-- Bottom nav -->
+    <com.google.android.material.bottomnavigation.BottomNavigationView
+        android:id="@+id/bottomNavigation"
+        android:layout_width="match_parent"
+        android:layout_height="74dp"
+        android:background="@color/bg_white"
+        app:itemTextColor="@color/text_hint"
+        app:menu="@menu/bottom_nav_menu_main_activity" />
+
+</LinearLayout>

--- a/code/app/src/main/res/layout/activity_event_detail.xml
+++ b/code/app/src/main/res/layout/activity_event_detail.xml
@@ -1,0 +1,267 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:background="@color/bg_light">
+
+    <!--Top Bar -->
+    <RelativeLayout
+        android:layout_width="match_parent"
+        android:layout_height="56dp"
+        android:paddingStart="16dp"
+        android:paddingEnd="16dp">
+
+        <ImageButton
+            android:id="@+id/btnBack"
+            android:layout_width="40dp"
+            android:layout_height="40dp"
+            android:layout_alignParentStart="true"
+            android:layout_centerVertical="true"
+            android:background="?attr/selectableItemBackgroundBorderless"
+            android:src="@drawable/ic_circle_arrow_left"
+            android:contentDescription="Back" />
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_centerInParent="true"
+            android:text="@string/app_name"
+            android:textColor="@color/text_primary"
+            android:fontFamily="@font/inter24ptmedium"
+            android:textSize="20sp"
+            android:textStyle="bold" />
+
+        <ImageView
+            android:layout_width="36dp"
+            android:layout_height="36dp"
+            android:layout_alignParentEnd="true"
+            android:layout_centerVertical="true"
+            android:src="@drawable/waitwell_logo"
+            android:contentDescription="Logo" />
+    </RelativeLayout>
+
+    <!-- Scrollable part -->
+    <ScrollView
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical">
+
+            <!-- Hero image area with overlays -->
+            <FrameLayout
+                android:layout_width="match_parent"
+                android:layout_height="360dp"
+                android:layout_marginStart="16dp"
+                android:layout_marginEnd="16dp">
+
+                <!-- Event poster -->
+                <ImageView
+                    android:id="@+id/imgEventPoster"
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent"
+                    android:scaleType="centerCrop"
+                    android:background="#C8E6C9"
+                    android:contentDescription="Event poster" />
+
+                <!-- Title + location + price overlay (bottom) -->
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="bottom"
+                    android:layout_marginStart="12dp"
+                    android:layout_marginEnd="12dp"
+                    android:layout_marginBottom="12dp"
+                    android:background="@drawable/bg_title_overlay"
+                    android:padding="14dp"
+                    android:orientation="horizontal">
+
+                    <LinearLayout
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:orientation="vertical">
+
+                        <TextView
+                            android:id="@+id/txtTitle"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="Yoga Hatha"
+                            android:fontFamily="@font/poppins"
+                            android:textColor="#FFFFFF"
+                            android:textSize="22sp"
+                            android:textStyle="bold"
+                            android:shadowColor="#88000000"
+                            android:shadowDx="0"
+                            android:shadowDy="1"
+                            android:shadowRadius="3" />
+
+                        <LinearLayout
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:layout_marginTop="4dp"
+                            android:gravity="center_vertical">
+
+                            <TextView
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:text="◉ "
+                                android:textColor="#FFFFFF"
+                                android:textSize="10sp" />
+
+                            <TextView
+                                android:id="@+id/txtLocation"
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:text="Edmonton, Alberta"
+                                android:fontFamily="@font/poppins"
+                                android:textColor="#FFFFFF"
+                                android:textSize="14sp" />
+                        </LinearLayout>
+                    </LinearLayout>
+
+                    <LinearLayout
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:gravity="center"
+                        android:orientation="vertical">
+
+                        <TextView
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="Price"
+                            android:textColor="#EEEEEE"
+                            android:textSize="11sp" />
+
+                        <TextView
+                            android:id="@+id/txtPrice"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="$10"
+                            android:textColor="#FFFFFF"
+                            android:textSize="22sp"
+                            android:textStyle="bold" />
+                    </LinearLayout>
+                </LinearLayout>
+            </FrameLayout>
+
+            <!-- Overview + Registered count -->
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="16dp"
+                android:paddingStart="20dp"
+                android:paddingEnd="20dp">
+
+                <TextView
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:text="Overview"
+                    android:textColor="@color/text_primary"
+                    android:fontFamily="@font/poppins"
+                    android:textSize="18sp"
+                    android:textStyle="bold" />
+
+                <TextView
+                    android:id="@+id/txtRegistered"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="14 Registered"
+                    android:textColor="@color/text_secondary"
+                    android:textSize="14sp" />
+            </LinearLayout>
+
+            <!-- Time remaining + rating -->
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="8dp"
+                android:paddingStart="20dp"
+                android:paddingEnd="20dp"
+                android:gravity="center_vertical">
+
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="◷ "
+                    android:textSize="16sp" />
+
+                <TextView
+                    android:id="@+id/txtTimeRemaining"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:text="Open to register for 2 more days"
+                    android:fontFamily="@font/poppins"
+                    android:textColor="@color/text_secondary"
+                    android:textSize="13sp" />
+
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="★ "
+                    android:textColor="#FFC107"
+                    android:textSize="16sp" />
+
+                <TextView
+                    android:id="@+id/txtRating"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="4.5"
+                    android:textColor="@color/text_secondary"
+                    android:textSize="13sp" />
+            </LinearLayout>
+
+            <!-- Description -->
+            <TextView
+                android:id="@+id/txtDescription"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="16dp"
+                android:paddingStart="20dp"
+                android:paddingEnd="20dp"
+                android:paddingBottom="80dp"
+                android:textColor="@color/text_secondary"
+                android:textSize="15sp"
+                android:lineSpacingMultiplier="1.5" />
+
+        </LinearLayout>
+    </ScrollView>
+
+    <!--Join Waitlist button-->
+    <FrameLayout
+        android:id="@+id/joinButtonContainer"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:padding="16dp"
+        android:background="@color/bg_light">
+
+        <androidx.appcompat.widget.AppCompatButton
+            android:id="@+id/btnJoinWaitlist"
+            android:layout_width="match_parent"
+            android:layout_height="54dp"
+            android:background="@drawable/bg_button_join"
+            android:fontFamily="@font/poppins"
+            android:text="Join Waitlist Now      ➤"
+            android:textAllCaps="false"
+            android:textColor="#FFFFFF"
+            android:textSize="16sp"
+            android:textStyle="bold" />
+    </FrameLayout>
+
+    <!-- Bottom Navigation-->
+    <com.google.android.material.bottomnavigation.BottomNavigationView
+        android:id="@+id/bottomNavigation"
+        android:layout_width="match_parent"
+        android:layout_height="74dp"
+        android:background="@color/bg_white"
+        app:itemTextColor="@color/text_hint"
+        app:menu="@menu/bottom_nav_menu_main_activity" />
+
+</LinearLayout>

--- a/code/app/src/main/res/layout/activity_main.xml
+++ b/code/app/src/main/res/layout/activity_main.xml
@@ -91,13 +91,13 @@
             </LinearLayout>
 
             <!-- "History" chip -->
+            <!-- History chip + Scan QR button in one row -->
             <LinearLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="12dp"
                 android:orientation="horizontal"
-                android:fontFamily="@font/inter"
-                >
+                android:gravity="center_vertical">
 
                 <TextView
                     android:id="@+id/chipHistory"
@@ -112,22 +112,26 @@
                     android:text="@string/history"
                     android:textColor="@color/text_secondary"
                     android:textSize="13sp" />
+
+                <androidx.appcompat.widget.AppCompatButton
+                    android:id="@+id/btnScanQr"
+                    android:layout_width="wrap_content"
+                    android:layout_height="36dp"
+                    android:layout_marginStart="10dp"
+                    android:background="@drawable/bg_filter_dropdown"
+                    android:backgroundTint="@null"
+                    android:paddingStart="14dp"
+                    android:paddingEnd="14dp"
+                    android:text="▶ Scan QR Code"
+                    android:textAllCaps="false"
+                    android:textColor="@color/text_secondary"
+                    android:textSize="13sp"
+                    app:backgroundTint="@null" />
+
+
+                    android:textSize="13sp" />
             </LinearLayout>
-
-            <!-- ▶ Scan QR Code button -->
             <!-- "Title >" section header -->
-
-            <Button
-                android:id="@+id/btnScanQr"
-                android:layout_width="match_parent"
-                android:layout_height="52dp"
-                android:layout_marginTop="16dp"
-                android:background="@drawable/bg_button_green"
-                android:fontFamily="@font/poppinsmedium"
-                android:text="▶ Scan QR Code"
-                android:textAllCaps="false"
-                android:textColor="@color/text_white"
-                android:textSize="15sp" />
 
             <LinearLayout
                 android:layout_width="wrap_content"

--- a/code/app/src/main/res/layout/activity_waitlist.xml
+++ b/code/app/src/main/res/layout/activity_waitlist.xml
@@ -1,0 +1,130 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:background="@color/bg_light">
+
+    <!-- Top bar -->
+    <RelativeLayout
+        android:layout_width="match_parent"
+        android:layout_height="56dp"
+        android:paddingStart="16dp"
+        android:paddingEnd="16dp">
+
+        <ImageButton
+            android:id="@+id/btnHamburger"
+            android:layout_width="40dp"
+            android:layout_height="40dp"
+            android:layout_alignParentStart="true"
+            android:layout_centerVertical="true"
+            android:background="?attr/selectableItemBackgroundBorderless"
+            android:src="@drawable/ic_menu_hamburger"
+            android:contentDescription="Menu" />
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_centerInParent="true"
+            android:text="@string/app_name"
+            android:fontFamily="@font/inter24ptmedium"
+            android:textColor="@color/text_primary"
+            android:textSize="20sp"
+            android:textStyle="bold" />
+
+        <ImageView
+            android:layout_width="36dp"
+            android:layout_height="36dp"
+            android:layout_alignParentEnd="true"
+            android:layout_centerVertical="true"
+            android:src="@drawable/waitwell_logo"
+            android:contentDescription="logo" />
+    </RelativeLayout>
+
+    <!-- Title -->
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:gravity="center"
+        android:paddingTop="4dp"
+        android:text="Your WaitList"
+        android:textColor="@color/text_primary"
+        android:textSize="22sp"
+        android:fontFamily="@font/inter24ptmedium"
+        android:textStyle="bold" />
+
+    <!-- "Event Status" label -->
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:gravity="end"
+        android:paddingEnd="20dp"
+        android:paddingTop="12dp"
+        android:text="Event Status"
+        android:textColor="@color/text_hint"
+        android:textSize="13sp" />
+
+    <!-- Entries list -->
+    <ScrollView
+        android:id="@+id/scrollEntries"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1"
+        android:paddingStart="16dp"
+        android:paddingEnd="16dp"
+        android:paddingTop="12dp"
+        android:clipToPadding="false">
+
+        <LinearLayout
+            android:id="@+id/entriesContainer"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical" />
+    </ScrollView>
+
+    <!-- Empty state -->
+    <LinearLayout
+        android:id="@+id/emptyState"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1"
+        android:gravity="center"
+        android:orientation="vertical"
+        android:visibility="gone">
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="You haven't joined any waitlists yet"
+            android:textColor="@color/text_hint"
+            android:textSize="15sp"
+            android:gravity="center" />
+    </LinearLayout>
+
+    <!-- Quit Waiting List button -->
+    <androidx.appcompat.widget.AppCompatButton
+        android:id="@+id/btnQuit"
+        android:layout_width="wrap_content"
+        android:layout_height="44dp"
+        android:layout_marginStart="16dp"
+        android:layout_marginBottom="12dp"
+        android:background="@drawable/bg_button_quit"
+        android:paddingStart="20dp"
+        android:paddingEnd="20dp"
+        android:text="Quit Waiting List"
+        android:textAllCaps="false"
+        android:textColor="#FFFFFF"
+        android:textSize="14sp"
+        android:visibility="gone" />
+
+    <!-- Bottom nav -->
+    <com.google.android.material.bottomnavigation.BottomNavigationView
+        android:id="@+id/bottomNavigation"
+        android:layout_width="match_parent"
+        android:layout_height="74dp"
+        android:background="@color/bg_white"
+        app:itemTextColor="@color/text_hint"
+        app:menu="@menu/bottom_nav_menu_main_activity" />
+
+</LinearLayout>

--- a/code/app/src/main/res/layout/item_waitlist_entry.xml
+++ b/code/app/src/main/res/layout/item_waitlist_entry.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_marginBottom="12dp"
+    android:gravity="center_vertical"
+    android:orientation="horizontal">
+
+    <!-- circle (visual) -->
+    <View
+        android:layout_width="22dp"
+        android:layout_height="22dp"
+        android:background="@drawable/ic_event_item" />
+
+    <!-- Card body -->
+    <LinearLayout
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_weight="1"
+        android:layout_marginStart="10dp"
+        android:background="@drawable/bg_waitlist_card"
+        android:gravity="center_vertical"
+        android:padding="16dp"
+        android:orientation="horizontal">
+
+        <TextView
+            android:id="@+id/txtNumber"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="1."
+            android:textColor="@color/text_primary"
+            android:textSize="16sp"
+            android:textStyle="bold" />
+
+        <TextView
+            android:id="@+id/txtEntryTitle"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:layout_marginStart="12dp"
+            android:fontFamily="@font/poppinsbold"
+            android:textColor="@color/text_primary"
+            android:textSize="16sp"
+           />
+
+        <TextView
+            android:id="@+id/txtEntryStatus"
+            android:layout_width="wrap_content"
+            android:layout_height="30dp"
+            android:gravity="center"
+            android:paddingStart="14dp"
+            android:paddingEnd="14dp"
+            android:textSize="13sp" />
+    </LinearLayout>
+</LinearLayout>

--- a/code/app/src/main/res/values/colors.xml
+++ b/code/app/src/main/res/values/colors.xml
@@ -20,4 +20,7 @@
     <color name="divider">#E0E0E0</color>
     <color name="black">#FF000000</color>
     <color name="white">#FFFFFFFF</color>
+
+    <color name="status_waiting_bg">#FFF9C4</color>
+    <color name="status_waiting_text">#F9A825</color>
 </resources>


### PR DESCRIPTION
…1.02 – leave a waitlist, each entry shows its status: Waiting / Selected / Rejected / Confirmed. Tapping a row navigates to that event's detail screen. Added event detail screen: Receives "event_id", loads the event from Firestore, if the user is already on this event's waitlist, the button is hidden and a message is shown instead. Added Confirmation Screen - displays the event name and "You're on the waiting list!"